### PR TITLE
Removing $sce.trustAsHtml for XSS prevention

### DIFF
--- a/src/angular-lightweight-markdown-editor.js
+++ b/src/angular-lightweight-markdown-editor.js
@@ -95,7 +95,8 @@
             if (!this.showdownEnabled) {
                 return "";
             }
-            return $sce.trustAsHtml(mdConverter.makeHtml(this.ngModel));
+		// Removing $sce.trustAsHtml allows ngSanitize to work on the HTML and provides XSS prevention
+            return mdConverter.makeHtml(this.ngModel);
         };
 
         this.options = angular.extend({}, defaultOptions, this.options);


### PR DESCRIPTION
Removing $sce.trustAsHtml allows ngSanitize to work on the HTML and provides XSS prevention